### PR TITLE
correct warning caused by 'nan' in comparison

### DIFF
--- a/python/discover/pairwise.py
+++ b/python/discover/pairwise.py
@@ -42,7 +42,7 @@ def pairwise_discover_test(x, g=None, alternative="less", correct=True):
         p[numpy.triu_indices_from(p, 1)] = pFlat
 
         q = numpy.empty((x.shape[0], ) * 2)
-        q[:] = numpy.nan
+        q[:] = numpy.inf
         q[numpy.triu_indices_from(p, 1)] = qFlat
     else:
         i = numpy.argsort(g)


### PR DESCRIPTION
Correct the following warning
RuntimeWarning: invalid value encountered in less
i, j = numpy.where(self.pi0 * numpy.asarray(self.qvalues) < q_threshold)